### PR TITLE
fix: shutdown chrome container after test execution

### DIFF
--- a/testrunner.sh
+++ b/testrunner.sh
@@ -83,8 +83,10 @@ git pull
 set -o pipefail
 timeout 30m docker compose run node 2>&1 | tee ~/test/test_output.log
 exitCode=$?
-
 echo "Exit code is $exitCode"
+
+# Shutdown the containers, to kill off residues of the test run that might interfere with future ones
+docker compose down
 
 cd ~/test
 attachmentString=`./failingScreenshots.sh | ./attachImages.sh`


### PR DESCRIPTION
[Apparently](https://stackoverflow.com/a/78694357/7700150) the problem was that multiple test executions happened on the same chrome container concurrently. This probably happened because the timeout killed the selenium container, but not the chrome container. By shutting down all the containers with `docker compose down` after the test execution (no matter if a timeout caused it or the normal exit), this problem *should* be fixed. I can't really test it right now, since a restart also might have solved the problem.

Note that right now this branch is already running on `develop`. After merging this PR, the `main` branch should be checked out on `develop` again.