### PR TITLE
Fix/screenshot nested tests

### DIFF
--- a/failingScreenshots.sh
+++ b/failingScreenshots.sh
@@ -15,7 +15,7 @@ while IFS= read -r line || [ -n "$line" ]; do
 		withoutIndentation=`echo "$withoutNumber" | xargs`
 		indentation=$((`echo "$withoutNumber" | wc -c`-`echo "$withoutIndentation" | wc -c`))
 		# Get the text of the failed test
-		text=`echo "$withoutNumber" | sed -E "s/^ +[0-9]+\) (.*)$/\1/"`
+		text=`echo "$withoutIndentation" | sed -E "s/^[0-9]+\) (.*)$/\1/"`
 
 		# Iterate through the nestings of the batches this failed test is contained in
 		batch=""

--- a/failingScreenshots.sh
+++ b/failingScreenshots.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
 # All lines that contain an indication of an error
-failingLines=`grep -E -n "^    [0-9]+)" test_output.log`
+failingLines=`grep -E -n "^ +[0-9]+) should" test_output.log`
 
 # For all the errors, find the appropriate screenshot
 while IFS= read -r line || [ -n "$line" ]; do
+	# There are no screenshots of hooks
 	notHook=`echo "$line" | grep --quiet 'all" hook' && echo "notHook"`
 	if [ -z "$notHook" ]; then
 		# Get the line number of the error indication; this is needed to find the batch
 		number=`echo "$line" | cut -f1 -d:`
+		withoutNumber=`echo "$line" | sed -E "s/^[0-9]+:(.*)$/\1/"`
+		# Get the indentation count to figure out how nested the test is
+		indentation=`echo "$withoutNumber" | sed -E "s/^( *).*/\1/" | tr -d '\n' | wc -c`
 		# Get the text of the failed test
-		text=`echo "$line" | sed -E "s/^[0-9]+: +[0-9]+\) (.*)$/\1/"`
+		text=`echo "$withoutNumber" | sed -E "s/^ +[0-9]+\) (.*)$/\1/"`
 		# Get the batch of the failed test; this is the last batch text before this test text
 		batch=`head -n "$number" test_output.log | grep -Ei "^  [a-zA-Z]+ test" | tail -n 1 | xargs`
 		# Construct the file name


### PR DESCRIPTION
Also upload screenshots of nested tests by figuring out the batches of all nesting depths. Note that this change required a change to the detection of what's the actual test and what's other random messages; for that I filtered for the `should` keyword after the `[0-9]+)` part. This required a change to `oeb-test`, so don't forget to review that [PR](https://github.com/mint-o-badges/oeb-test/pull/48).